### PR TITLE
Fix: set full height container to 100vh min-height

### DIFF
--- a/app/main.css
+++ b/app/main.css
@@ -99,8 +99,8 @@ ul {
 
 /* Main content */
 .container {
-	width: 100%;
-	min-height: 100%;
+	width: 100vw;
+	min-height: 100vh;
 	max-width: 1450px;
 	padding: 0;
 	position: relative;


### PR DESCRIPTION
- The css for the full-screen container was set for 100%.
  - Setting to 100vh makes it show fullscreen as intended
