### PR TITLE
Fix: when creating new address array, parse the index as a number first

### DIFF
--- a/app/components/UserProfilePage/AddressList.js
+++ b/app/components/UserProfilePage/AddressList.js
@@ -20,7 +20,7 @@ const AddressList = ({
               handleToggle={handleToggle}
               handleRemoveAddress={handleRemoveAddress}
             />
-            <Divider />
+          <Divider key={i + 1 * Math.random()} />
           </div>
         )}
       </List>

--- a/app/components/UserProfilePage/AddressListItem.js
+++ b/app/components/UserProfilePage/AddressListItem.js
@@ -20,7 +20,7 @@ const AddressListItem = ({
   index,
   handleRemoveAddress
 }) => (
-  <ListItem>
+  <ListItem key={index}>
     <div className="flex-row">
       <DefaultCheckbox
         handleToggle={handleToggle}

--- a/app/pages/UserProfilePage.jsx
+++ b/app/pages/UserProfilePage.jsx
@@ -401,7 +401,7 @@ If error occurs, logout user and return to homepage.
  */
   handleRemoveAddress(i) {
     const formData = this.state.formData;
-    const elementId = i.target.id;
+    const elementId = parseInt(i.target.id, 10);
     const newFormData = Object.assign({}, formData, {
       addresses: [
         ...formData.addresses.slice(0, elementId),


### PR DESCRIPTION
- As noted, the array was being cut off at the end when deleting an item
- The issue was that the event.target.id was a string, so the index + 1 was returning god knows what
